### PR TITLE
Add codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+*       @Team488/core-robot-maintainers


### PR DESCRIPTION
# Why are we doing this?
Today, when students open PRs they need to manually add all the relevant mentors as reviewers.

This codeowners file will mean that all PRs will get the main core mentors added as reviewers (and since it's a [team ](https://github.com/orgs/Team488/teams/core-robot-maintainers)we can do it again later).


