### PR TITLE
Add workflow to attach PRs to asana tickets from description urls

### DIFF
--- a/.github/workflows/comment-on-task.yaml
+++ b/.github/workflows/comment-on-task.yaml
@@ -1,6 +1,6 @@
 on:
   pull_request:
-    types: [opened, closed, reopened]
+    types: [opened, closed, reopened, edited, converted_to_draft, ready_for_review]
 
 jobs:
   create-comment-in-asana-task-job:

--- a/.github/workflows/create-asana-attachment.yml
+++ b/.github/workflows/create-asana-attachment.yml
@@ -1,6 +1,6 @@
 on:
   pull_request:
-    types: [opened, reopened]
+    types: [opened, reopened, edited, converted_to_draft, ready_for_review]
 
 jobs:
   create-asana-attachment-job:


### PR DESCRIPTION
# Why are we doing this?
We are often tracking work in Asana that leads to pull requests. Keeping the two places in sync is today manual and tedius.

For example, often a pull request will get closed but the task in question is left floating in asana.

Ticket: https://app.asana.com/0/2086228412422/1206397614455708
# Whats changing?

Adds 2 new github workflows from Asana:
- https://github.com/marketplace/actions/attach-pull-request-to-asana-task
- https://github.com/Asana/comment-on-task-github-action



# Questions/notes for reviewers

# How this was tested
This PR linked to an asana ticket in the description above and now we can see the status there inline in asana:

![image](https://github.com/Team488/XBot2024/assets/399279/c7980b89-0e97-4af9-be72-1aca2bcf8e79)
