### PR TITLE
Both fundamental and advanced gamepads can move the arm.

### DIFF
--- a/src/main/java/competition/subsystems/arm/commands/ArmMaintainerCommand.java
+++ b/src/main/java/competition/subsystems/arm/commands/ArmMaintainerCommand.java
@@ -119,10 +119,17 @@ public class ArmMaintainerCommand extends BaseMaintainerCommand<Double> {
 
     @Override
     protected Double getHumanInput() {
-        return MathUtils.deadband(
+        double fundamentalInput = MathUtils.deadband(
                 oi.operatorFundamentalsGamepad.getLeftVector().y,
                 oi.getOperatorGamepadTypicalDeadband(),
                 (x) -> x);
+
+        double advancedInput = MathUtils.deadband(
+                oi.operatorGamepadAdvanced.getLeftVector().y,
+                oi.getOperatorGamepadTypicalDeadband(),
+                (x) -> x);
+
+        return fundamentalInput + advancedInput;
     }
 
     @Override


### PR DESCRIPTION
# Why are we doing this?
The operator wants to move the arm without activating other systems (e.g. not run the collector)
Asana task URL:

# Whats changing?
ArmMaintainerCommand listens to both gamepads' left joysticks.
# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [ ] tested on robot
