### PR TITLE
Track Compressor Usage in a match

### DIFF
--- a/src/main/java/competition/subsystems/arm/ArmSubsystem.java
+++ b/src/main/java/competition/subsystems/arm/ArmSubsystem.java
@@ -8,12 +8,14 @@ import competition.subsystems.pose.PoseSubsystem;
 import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.math.geometry.Rotation3d;
 import edu.wpi.first.math.geometry.Translation3d;
+import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.smartdashboard.Mechanism2d;
 import edu.wpi.first.wpilibj.smartdashboard.MechanismLigament2d;
 import edu.wpi.first.wpilibj.util.Color8Bit;
 import xbot.common.advantage.DataFrameRefreshable;
 import xbot.common.command.BaseSetpointSubsystem;
 import xbot.common.controls.actuators.XCANSparkMax;
+import xbot.common.controls.actuators.XCompressor;
 import xbot.common.controls.actuators.XDoubleSolenoid;
 import xbot.common.controls.actuators.XSolenoid;
 import xbot.common.controls.sensors.XSparkAbsoluteEncoder;
@@ -75,6 +77,10 @@ public class ArmSubsystem extends BaseSetpointSubsystem<Double> implements DataF
     private final DoubleProperty powerRampDurationSec;
     private boolean powerRampingEnabled = true;
     private boolean dynamicBrakingEnabled = false;
+    private final XCompressor compressor;
+    private int totalLoops = 0;
+    private int loopsWhereCompressorRunning = 0;
+
 
     public enum ArmState {
         EXTENDING,
@@ -104,9 +110,10 @@ public class ArmSubsystem extends BaseSetpointSubsystem<Double> implements DataF
                         XDoubleSolenoid.XDoubleSolenoidFactory doubleSolenoidFactory,
                         XSolenoid.XSolenoidFactory solenoidFactory,
                         ElectricalContract contract, PoseSubsystem pose,
-                        DriveSubsystem drive) {
+                        DriveSubsystem drive, XCompressor.XCompressorFactory compressorFactory) {
 
         this.pose = pose;
+        this.compressor = compressorFactory.create();
 
         armBrakeSolenoid = doubleSolenoidFactory.create(
                 solenoidFactory.create(contract.getBrakeSolenoidForward().channel),
@@ -642,6 +649,16 @@ public class ArmSubsystem extends BaseSetpointSubsystem<Double> implements DataF
         armLigament.setAngle(getArmAngle() - armPivotAngleAtArmAngleZero);
         armLigament.setColor(color);
         aKitLog.record("Arm2dStateActual", armActual2d);
+
+        if (DriverStation.isEnabled()) {
+            totalLoops++;
+            if (!compressor.isAtTargetPressure()) {
+                loopsWhereCompressorRunning++;
+            }
+        }
+        if (totalLoops > 0) {
+            aKitLog.record("CompressorRunningPercentage", (loopsWhereCompressorRunning * 100) / totalLoops);
+        }
     }
 
 


### PR DESCRIPTION
# Why are we doing this?
To enable engineering decisions like "should we add another accumulator?"
Asana task URL:

# Whats changing?
- Arm logs the rough % of time the compressor is activated to AKIT
# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [ ] tested on robot
