### PR TITLE
Make "point at special target" swerve generic

### DIFF
--- a/src/main/java/competition/operator_interface/OperatorCommandMap.java
+++ b/src/main/java/competition/operator_interface/OperatorCommandMap.java
@@ -1,20 +1,16 @@
 package competition.operator_interface;
 
-import competition.commandgroups.PrepareToFireAtSpeakerFromFarAmpCommand;
-import competition.subsystems.oracle.ListenToOracleCommandGroup;
 import competition.auto_programs.SubwooferShotFromBotShootThenShootBotSpikeThenShootBotCenter;
 import competition.auto_programs.SubwooferShotFromBotShootThenShootSpikes;
 import competition.auto_programs.SubwooferShotFromMidShootThenShootNearestThree;
 import competition.auto_programs.SubwooferShotFromTopShootThenShootSpikes;
 import competition.auto_programs.SubwooferShotFromTopShootThenShootTopSpikeThenShootTopCenter;
-import competition.commandgroups.PrepareToFireAtSpeakerCommandGroup;
+import competition.commandgroups.PrepareToFireAtSpeakerFromFarAmpCommand;
+import competition.commandgroups.PrepareToFireAtSpeakerFromPodiumCommand;
 import competition.subsystems.arm.ArmSubsystem;
 import competition.subsystems.arm.commands.CalibrateArmsManuallyCommand;
 import competition.subsystems.arm.commands.ContinuouslyPointArmAtSpeakerCommand;
-import competition.subsystems.arm.commands.DisengageBrakeCommand;
-import competition.subsystems.arm.commands.EngageBrakeCommand;
 import competition.subsystems.arm.commands.ManualHangingModeCommand;
-import competition.subsystems.arm.commands.SetArmAngleCommand;
 import competition.subsystems.arm.commands.SetArmExtensionCommand;
 import competition.subsystems.collector.commands.EjectCollectorCommand;
 import competition.subsystems.collector.commands.FireCollectorCommand;
@@ -24,15 +20,14 @@ import competition.subsystems.drive.commands.AlignToNoteCommand;
 import competition.subsystems.drive.commands.DriveToAmpCommand;
 import competition.subsystems.drive.commands.DriveToCentralSubwooferCommand;
 import competition.subsystems.oracle.DynamicOracle;
+import competition.subsystems.oracle.ListenToOracleCommandGroup;
 import competition.subsystems.pose.PoseSubsystem;
 import competition.subsystems.schoocher.commands.EjectScoocherCommand;
 import competition.subsystems.schoocher.commands.IntakeScoocherCommand;
 import competition.subsystems.shooter.ShooterWheelSubsystem;
 import competition.subsystems.shooter.commands.ContinuouslyWarmUpForSpeakerCommand;
 import competition.subsystems.shooter.commands.FireWhenReadyCommand;
-import competition.commandgroups.PrepareToFireAtSpeakerFromPodiumCommand;
 import competition.subsystems.shooter.commands.WarmUpShooterCommand;
-import competition.subsystems.shooter.commands.WarmUpShooterRPMCommand;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import xbot.common.controls.sensors.XXboxController.XboxButton;
@@ -102,10 +97,25 @@ public class OperatorCommandMap {
         // Rotation calibration routine
         resetHeading.setHeadingToApply(() -> PoseSubsystem.convertBlueToRedIfNeeded(Rotation2d.fromDegrees(180)).getDegrees());
 
+        var pointAtSpeaker = drive.createSetSpecialPointAtPositionTargetCommand(
+                () -> PoseSubsystem.convertBlueToRedIfNeeded(PoseSubsystem.SPEAKER_POSITION));
+
+        var pointAtSource = drive.createSetSpecialHeadingTargetCommand(
+                () -> PoseSubsystem.convertBlueToRedIfNeeded(PoseSubsystem.FaceCollectorToBlueSource));
+
+        var clearSpecialTargets = drive.createClearAllSpecialTargetsCommand();
+
+
         operatorInterface.driverGamepad.getXboxButton(XboxButton.Start).onTrue(resetHeading);
         operatorInterface.driverGamepad.getXboxButton(XboxButton.A).whileTrue(alignToNoteCommand);
         operatorInterface.driverGamepad.getXboxButton(XboxButton.X).whileTrue(driveToCentralSubwooferCommand);
         operatorInterface.driverGamepad.getXboxButton(XboxButton.B).whileTrue(driveToAmpCommand);
+        operatorInterface.driverGamepad.getXboxButton(XboxButton.Y)
+                .onTrue(pointAtSpeaker)
+                .onFalse(clearSpecialTargets);
+        operatorInterface.driverGamepad.getXboxButton(XboxButton.RightBumper)
+                .onTrue(pointAtSource)
+                .onFalse(clearSpecialTargets);
     }
 
     @Inject

--- a/src/main/java/competition/subsystems/drive/DriveSubsystem.java
+++ b/src/main/java/competition/subsystems/drive/DriveSubsystem.java
@@ -1,6 +1,9 @@
 package competition.subsystems.drive;
 
 import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.wpilibj2.command.InstantCommand;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import xbot.common.advantage.DataFrameRefreshable;
@@ -16,12 +19,18 @@ import xbot.common.subsystems.drive.BaseSwerveDriveSubsystem;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import java.util.function.Supplier;
 
 @Singleton
 public class DriveSubsystem extends BaseSwerveDriveSubsystem implements DataFrameRefreshable {
     private static final Logger log = LogManager.getLogger(DriveSubsystem.class);
 
     private Pose2d targetNote;
+
+    private boolean specialHeadingTargetActive = false;
+    private boolean specialPointAtPositionTargetActive = false;
+    private Rotation2d specialHeadingTarget = new Rotation2d();
+    private Translation2d specialPointAtPositionTarget = new Translation2d();
 
     @Inject
     public DriveSubsystem(PIDManagerFactory pidFactory, PropertyFactory pf,
@@ -47,6 +56,59 @@ public class DriveSubsystem extends BaseSwerveDriveSubsystem implements DataFram
 
     public Pose2d getTargetNote() {
         return targetNote;
+    }
+
+    public void setSpecialHeadingTarget(Rotation2d specialHeadingTarget) {
+        this.specialHeadingTarget = specialHeadingTarget;
+    }
+
+    public Rotation2d getSpecialHeadingTarget() {
+        return specialHeadingTarget;
+    }
+
+    public void setSpecialHeadingTargetActive(boolean specialHeadingTargetActive) {
+        this.specialHeadingTargetActive = specialHeadingTargetActive;
+    }
+
+    public boolean isSpecialHeadingTargetActive() {
+        return specialHeadingTargetActive;
+    }
+
+    public void setSpecialPointAtPositionTarget(Translation2d specialPointAtPositionTarget) {
+        this.specialPointAtPositionTarget = specialPointAtPositionTarget;
+    }
+
+    public Translation2d getSpecialPointAtPositionTarget() {
+        return specialPointAtPositionTarget;
+    }
+
+    public void setSpecialPointAtPositionTargetActive(boolean specialPointAtPositionTargetActive) {
+        this.specialPointAtPositionTargetActive = specialPointAtPositionTargetActive;
+    }
+
+    public boolean isSpecialPointAtPositionTargetActive() {
+        return specialPointAtPositionTargetActive;
+    }
+
+    public InstantCommand createSetSpecialHeadingTargetCommand(Supplier<Rotation2d> specialHeadingTarget) {
+        return new InstantCommand(() -> {
+            setSpecialHeadingTarget(specialHeadingTarget.get());
+            setSpecialHeadingTargetActive(true);
+        });
+    }
+
+    public InstantCommand createSetSpecialPointAtPositionTargetCommand(Supplier<Translation2d> specialPointAtPositionTarget) {
+        return new InstantCommand(() -> {
+            setSpecialPointAtPositionTarget(specialPointAtPositionTarget.get());
+            setSpecialPointAtPositionTargetActive(true);
+        });
+    }
+
+    public InstantCommand createClearAllSpecialTargetsCommand() {
+        return new InstantCommand(() -> {
+            setSpecialHeadingTargetActive(false);
+            setSpecialPointAtPositionTargetActive(false);
+        });
     }
 
 }

--- a/src/main/java/competition/subsystems/pose/PoseSubsystem.java
+++ b/src/main/java/competition/subsystems/pose/PoseSubsystem.java
@@ -81,7 +81,7 @@ public class PoseSubsystem extends BasePoseSubsystem {
     public static Pose2d BlueSpikeTopWhiteLine = new Pose2d(1.93294, 7.0012, new Rotation2d());
     public static Pose2d BlueSpikeBottomWhiteLine = new Pose2d(1.93294, 4.1056, new Rotation2d());
 
-
+    public static Rotation2d FaceCollectorToBlueSource = Rotation2d.fromDegrees(120);
 
 
     private DoubleProperty matchTime;


### PR DESCRIPTION
# Why are we doing this?
Driver wants some "force the robot to point at something" buttons. Since we may need to do this for several cases, made the existing code generic and support pointing at points on the field or hardcoded angles.
Asana task URL:

# Whats changing?
* DriveSubsystem now can hold onto special aim targets (either Rotation2d or Translation2d)
* SwerveDriveWithJoysticksCommand checks if special modes are activated and rotate to those targets
# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [ ] tested on robot
- [x] tested in simulator 
