### PR TITLE
Force Engage brake commands

### DIFF
--- a/src/main/java/competition/operator_interface/OperatorCommandMap.java
+++ b/src/main/java/competition/operator_interface/OperatorCommandMap.java
@@ -10,7 +10,9 @@ import competition.commandgroups.PrepareToFireAtSpeakerFromPodiumCommand;
 import competition.subsystems.arm.ArmSubsystem;
 import competition.subsystems.arm.commands.CalibrateArmsManuallyCommand;
 import competition.subsystems.arm.commands.ContinuouslyPointArmAtSpeakerCommand;
+import competition.subsystems.arm.commands.ForceEngageBrakeCommand;
 import competition.subsystems.arm.commands.ManualHangingModeCommand;
+import competition.subsystems.arm.commands.RemoveForcedBrakingCommand;
 import competition.subsystems.arm.commands.SetArmExtensionCommand;
 import competition.subsystems.collector.commands.EjectCollectorCommand;
 import competition.subsystems.collector.commands.FireCollectorCommand;
@@ -174,7 +176,9 @@ public class OperatorCommandMap {
             FireWhenReadyCommand fireWhenReady,
             PrepareToFireAtSpeakerFromPodiumCommand prepareToFireAtSpeakerFromPodium,
             PrepareToFireAtSpeakerFromFarAmpCommand prepareToFireAtSpeakerFromFarAmp,
-            ManualHangingModeCommand manualHangingModeCommand
+            ManualHangingModeCommand manualHangingModeCommand,
+            ForceEngageBrakeCommand forceEngageBrakeCommand,
+            RemoveForcedBrakingCommand removeForcedBrakingCommand
     ) {
         //Useful arm positions
         var armToCollection = setArmExtensionCommandProvider.get();
@@ -216,6 +220,8 @@ public class OperatorCommandMap {
         var continuouslyPrepareToFireAtSpeaker =
                 continuouslyWarmUpForSpeaker.alongWith(continuouslyPointArmAtSpeaker);
 
+        // Forcing Brakes
+
         // Bind to buttons
         oi.operatorGamepadAdvanced.getXboxButton(XboxButton.LeftTrigger).whileTrue(collectNoteFromGround);
         oi.operatorGamepadAdvanced.getXboxButton(XboxButton.RightTrigger).whileTrue(fireWhenReady.repeatedly());
@@ -228,6 +234,8 @@ public class OperatorCommandMap {
         oi.operatorGamepadAdvanced.getXboxButton(XboxButton.A).whileTrue(continuouslyPrepareToFireAtSpeaker);
         oi.operatorGamepadAdvanced.getXboxButton(XboxButton.B).whileTrue(prepareToFireAtSpeakerFromPodium);
         oi.operatorGamepadAdvanced.getPovIfAvailable(0).whileTrue(collectNoteFromSource);
+        oi.operatorGamepadAdvanced.getXboxButton(XboxButton.RightJoystickYAxisPositive).whileTrue(forceEngageBrakeCommand);
+        oi.operatorGamepadAdvanced.getXboxButton(XboxButton.RightJoystickYAxisNegative).whileTrue(removeForcedBrakingCommand);
     }
     
     @Inject

--- a/src/main/java/competition/subsystems/arm/commands/ForceEngageBrakeCommand.java
+++ b/src/main/java/competition/subsystems/arm/commands/ForceEngageBrakeCommand.java
@@ -1,0 +1,23 @@
+package competition.subsystems.arm.commands;
+
+import competition.subsystems.arm.ArmSubsystem;
+import xbot.common.command.BaseCommand;
+
+import javax.inject.Inject;
+import javax.naming.InitialContext;
+
+public class ForceEngageBrakeCommand extends BaseCommand {
+
+    ArmSubsystem arm;
+
+    @Inject
+    public ForceEngageBrakeCommand(ArmSubsystem arm) {
+        this.arm = arm;
+    }
+
+    @Override
+    public void initialize() {
+        log.info("Initializing");
+        arm.setForceBrakesEngaged(true);
+    }
+}

--- a/src/main/java/competition/subsystems/arm/commands/ManipulateArmBrakeCommand.java
+++ b/src/main/java/competition/subsystems/arm/commands/ManipulateArmBrakeCommand.java
@@ -4,7 +4,6 @@ import competition.subsystems.arm.ArmSubsystem;
 import xbot.common.command.BaseCommand;
 
 import javax.inject.Inject;
-import java.lang.reflect.Executable;
 
 public class ManipulateArmBrakeCommand extends BaseCommand {
 
@@ -25,7 +24,7 @@ public class ManipulateArmBrakeCommand extends BaseCommand {
     public void initialize() {
         log.info("Initializing");
         log.info("Setting arm brake to " + brakeEngaged);
-        arm.setBrakeEnabled(brakeEngaged);
+        arm.setBrakeState(brakeEngaged);
     }
 
     @Override

--- a/src/main/java/competition/subsystems/arm/commands/RemoveForcedBrakingCommand.java
+++ b/src/main/java/competition/subsystems/arm/commands/RemoveForcedBrakingCommand.java
@@ -1,0 +1,22 @@
+package competition.subsystems.arm.commands;
+
+import competition.subsystems.arm.ArmSubsystem;
+import xbot.common.command.BaseCommand;
+
+import javax.inject.Inject;
+
+public class RemoveForcedBrakingCommand extends BaseCommand {
+
+    ArmSubsystem arm;
+
+    @Inject
+    public RemoveForcedBrakingCommand(ArmSubsystem arm) {
+        this.arm = arm;
+    }
+
+    @Override
+    public void initialize() {
+        log.info("Initializing");
+        arm.setForceBrakesEngaged(false);
+    }
+}


### PR DESCRIPTION
# Why are we doing this?
When we go to hang, we want to be 1000% sure the brakes are locked in and going to stay locked, even if we let go of any buttons on the gamepad.
Asana task URL:

# What's changing?
* Operator right stick can now force brakes engaged/disengaged permanently (all other braking commands are ignored).

# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [ ] tested on robot
