### PR TITLE
Reorganize command map in gamepad order

### DIFF
--- a/src/main/java/competition/operator_interface/OperatorCommandMap.java
+++ b/src/main/java/competition/operator_interface/OperatorCommandMap.java
@@ -155,7 +155,7 @@ public class OperatorCommandMap {
         oi.operatorGamepadAdvanced.getXboxButton(XboxButton.RightJoystickYAxisPositive).whileTrue(forceEngageBrakeCommand);
         oi.operatorGamepadAdvanced.getXboxButton(XboxButton.RightJoystickYAxisNegative).whileTrue(removeForcedBrakingCommand);
         oi.operatorGamepadAdvanced.getPovIfAvailable(0).whileTrue(collectNoteFromSource);
-        oi.operatorGamepadAdvanced.getPovIfAvailable(-180).whileTrue(manualHangingModeCommand);
+        oi.operatorGamepadAdvanced.getPovIfAvailable(180).whileTrue(manualHangingModeCommand);
     }
 
     @Inject


### PR DESCRIPTION
# Why are we doing this?
The operator map needs to be more readable before we go into competition. We don't want to hunt around for what button is mapped to what command if we need to make rapid changes at the event.
Asana task URL:

# Whats changing?
* Functions are organized by gamepad, with a similar pattern for button ordering
* Extra functions to help construct commands are moved to the bottom
* Tried to follow the drive team doc for button mapping

# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [ ] tested on robot
