### PR TITLE
Arm Auto Brake at end of match if hang plausible

### DIFF
--- a/src/main/java/competition/subsystems/arm/ArmSubsystem.java
+++ b/src/main/java/competition/subsystems/arm/ArmSubsystem.java
@@ -644,6 +644,10 @@ public class ArmSubsystem extends BaseSetpointSubsystem<Double> implements DataF
         return manualHangingModeEngaged;
     }
 
+    public boolean couldPlausiblyBeHanging() {
+        return getExtensionDistance() < 15;
+    }
+
     public void setManualHangingMode(boolean enabled) {
         manualHangingModeEngaged = enabled;
     }

--- a/src/main/java/competition/subsystems/arm/commands/ArmMaintainerCommand.java
+++ b/src/main/java/competition/subsystems/arm/commands/ArmMaintainerCommand.java
@@ -65,7 +65,7 @@ public class ArmMaintainerCommand extends BaseMaintainerCommand<Double> {
     }
 
     private boolean shouldFreezeArmSinceEndOfMatch() {
-        return DriverStation.getMatchTime() < 1 && arm.getManualHangingMode();
+        return DriverStation.getMatchTime() < 1 && arm.couldPlausiblyBeHanging();
     }
 
     @Override


### PR DESCRIPTION
# Why are we doing this?
Turning on the brakes at the last second is a great idea, but I want to add an additional safeguard; we should only do it if the robot is plausibly hanging (where the arm is almost all the way down). I want to avoid a scenario where the drive team is trying to hang right at the buzzer with no time left and the brake engages too early.
Asana task URL:

# Whats changing?
* Last-minute check happens in both automatic and manual mods
* Brake only engages if arm is lower than a threshold (15mm based on eyeballing the robot) and less than one second remains.
# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [x] tested on robot
