### PR TITLE
changes to dynamic arm angle

### DIFF
--- a/src/main/java/competition/subsystems/arm/commands/ContinuouslyPointArmAtSpeakerCommand.java
+++ b/src/main/java/competition/subsystems/arm/commands/ContinuouslyPointArmAtSpeakerCommand.java
@@ -26,6 +26,6 @@ public class ContinuouslyPointArmAtSpeakerCommand extends BaseSetpointCommand {
 
     @Override
     public void execute() {
-        arm.setTargetValue(arm.getRecommendedExtension(pose.getDistanceFromSpeaker()));
+        arm.setTargetValue(arm.getModeledExtensionForGivenSpeakerDistance(pose.getDistanceFromSpeaker()));
     }
 }


### PR DESCRIPTION
# Why are we doing this?
getRecommendedExtension doesn't move the arm, it is the wrong method.


# Whats changing?
uses getModeledExtensionForGivenSpeakerDistance instead of getRecommendedExtension

# How this was tested
- tested on robot
