### PR TITLE
Update PointAtNoteCommand to use new SCL field oriented gamepad vectors

### DIFF
--- a/src/main/java/competition/subsystems/arm/commands/ArmMaintainerCommand.java
+++ b/src/main/java/competition/subsystems/arm/commands/ArmMaintainerCommand.java
@@ -152,12 +152,12 @@ public class ArmMaintainerCommand extends BaseMaintainerCommand<Double> {
     @Override
     protected Double getHumanInput() {
         double fundamentalInput = MathUtils.deadband(
-                oi.operatorFundamentalsGamepad.getLeftVector().y,
+                oi.operatorFundamentalsGamepad.getLeftVector().getY(),
                 oi.getOperatorGamepadTypicalDeadband(),
                 (x) -> x);
 
         double advancedInput = MathUtils.deadband(
-                oi.operatorGamepadAdvanced.getLeftVector().y,
+                oi.operatorGamepadAdvanced.getLeftVector().getY(),
                 oi.getOperatorGamepadTypicalDeadband(),
                 (x) -> x);
 

--- a/src/main/java/competition/subsystems/drive/commands/PointAtNoteCommand.java
+++ b/src/main/java/competition/subsystems/drive/commands/PointAtNoteCommand.java
@@ -83,8 +83,7 @@ public class PointAtNoteCommand extends BaseCommand {
         // if we're very close to the note, stop trying to rotate, it gets wonky
 
         var movement = MathUtils.deadband(
-                getDriveIntent(toNoteTranslation, oi.driverGamepad.getLeftVector(),
-                        DriverStation.getAlliance().orElse(DriverStation.Alliance.Blue)),
+                getDriveIntent(toNoteTranslation, oi.driverGamepad.getLeftFieldOrientedVector()),
                 oi.getDriverGamepadTypicalDeadband(), (x) -> x);
         double rotationPower = 0;
         // if we're far enough away, rotate towards the note (if we're too close, the )
@@ -96,14 +95,9 @@ public class PointAtNoteCommand extends BaseCommand {
         drive.move(new XYPair(-movement, 0), rotationPower);
     }
 
-    public static double getDriveIntent(Translation2d fieldTranslationToTarget, XYPair driveJoystick, Alliance alliance) {
+    public static double getDriveIntent(Translation2d fieldTranslationToTarget, Translation2d driveJoystick) {
         var toNoteVector = fieldTranslationToTarget.toVector().unit();
-        var driverVector = VecBuilder.fill(driveJoystick.y, -driveJoystick.x);
-        if(alliance == DriverStation.Alliance.Red) {
-            // invert both axis
-            driverVector = driverVector.div(-1);
-        }
-        var dot = toNoteVector.dot(driverVector);
+        var dot = toNoteVector.dot(driveJoystick.toVector());
 
         return dot;
     }

--- a/src/main/java/competition/subsystems/drive/commands/TankDriveWithJoysticksCommand.java
+++ b/src/main/java/competition/subsystems/drive/commands/TankDriveWithJoysticksCommand.java
@@ -27,8 +27,8 @@ public class TankDriveWithJoysticksCommand extends BaseCommand {
     @Override
     public void execute() {
         driveSubsystem.tankDrive(
-            MathUtils.deadband(oi.driverGamepad.getLeftVector().y, 0.15),
-            MathUtils.deadband(oi.driverGamepad.getRightVector().y, 0.15)
+            MathUtils.deadband(oi.driverGamepad.getLeftVector().getY(), 0.15),
+            MathUtils.deadband(oi.driverGamepad.getRightVector().getY(), 0.15)
         );
     }
 }

--- a/src/test/java/competition/subsystems/drive/PointAtNoteCommandTest.java
+++ b/src/test/java/competition/subsystems/drive/PointAtNoteCommandTest.java
@@ -14,46 +14,24 @@ import xbot.common.math.XYPair;
 public class PointAtNoteCommandTest extends BaseCompetitionTest {
     
     @Test
-    public void testGetDriveIntentBlue() {
-        var alliance = Alliance.Blue;
+    public void testGetDriveIntent() {
         // completely aligned with the direction we want to go
         // exact y
-        assertEquals( 1.0, PointAtNoteCommand.getDriveIntent(new Translation2d(0, 5), new XYPair(-1, 0), alliance), 0.001);
+        assertEquals( 1.0, PointAtNoteCommand.getDriveIntent(new Translation2d(0, 5), new Translation2d(0, 1)), 0.001);
         // exact x
-        assertEquals( 1.0, PointAtNoteCommand.getDriveIntent(new Translation2d(5, 0), new XYPair(0, 1), alliance), 0.001);
+        assertEquals( 1.0, PointAtNoteCommand.getDriveIntent(new Translation2d(5, 0), new Translation2d(1, 0)), 0.001);
 
 
         // exact opposite y
-        assertEquals(-1, PointAtNoteCommand.getDriveIntent(new Translation2d(0, 5), new XYPair(1, 0), alliance), 0.001);
+        assertEquals(-1, PointAtNoteCommand.getDriveIntent(new Translation2d(0, 5), new Translation2d(0, -1)), 0.001);
         // exact opposite x
-        assertEquals(-1, PointAtNoteCommand.getDriveIntent(new Translation2d(5, 0), new XYPair(0, -1), alliance), 0.001);
+        assertEquals(-1, PointAtNoteCommand.getDriveIntent(new Translation2d(5, 0), new Translation2d(-1, 0)), 0.001);
 
         // 45 degrees should be half power
-        assertEquals(0.5, PointAtNoteCommand.getDriveIntent(new Translation2d(5, 0), new XYPair(0.5, 0.5), alliance), 0.001);
+        assertEquals(0.5, PointAtNoteCommand.getDriveIntent(new Translation2d(5, 0), new Translation2d(0.5, 0.5)), 0.001);
 
         // small floating joystick number
-        assertTrue(Math.abs(PointAtNoteCommand.getDriveIntent(new Translation2d(5, 0), new XYPair(0.01, 0.01), alliance)) < 0.02);
+        assertTrue(Math.abs(PointAtNoteCommand.getDriveIntent(new Translation2d(5, 0), new Translation2d(0.01, 0.01))) < 0.02);
     }
 
-    @Test
-    public void testGetDriveIntentRed() {
-        var alliance = Alliance.Red;
-        // completely aligned with the direction we want to go
-        // exact y
-        assertEquals( 1.0, PointAtNoteCommand.getDriveIntent(new Translation2d(0, -5), new XYPair(-1, 0), alliance), 0.001);
-        // exact x
-        assertEquals( 1.0, PointAtNoteCommand.getDriveIntent(new Translation2d(-5, 0), new XYPair(0, 1), alliance), 0.001);
-
-
-        // exact opposite y
-        assertEquals(-1, PointAtNoteCommand.getDriveIntent(new Translation2d(0, -5), new XYPair(1, 0), alliance), 0.001);
-        // exact opposite x
-        assertEquals(-1, PointAtNoteCommand.getDriveIntent(new Translation2d(-5, 0), new XYPair(0, -1), alliance), 0.001);
-
-        // 45 degrees should be half power
-        assertEquals(0.5, PointAtNoteCommand.getDriveIntent(new Translation2d(-5, 0), new XYPair(0.5, 0.5), alliance), 0.001);
-
-        // small floating joystick number
-        assertTrue(Math.abs(PointAtNoteCommand.getDriveIntent(new Translation2d(-5, 0), new XYPair(0.01, 0.01), alliance)) < 0.02);
-    }
 }


### PR DESCRIPTION
# Why are we doing this?

I found writing this field oriented logic in PointAtNoteCommand confusing and error prone. 

# Whats changing?

Inside SCL there's now a method on gamepad to get field oriented vectors for joysticks to make subsequent math easy hopefully. This depends on SCL PR: https://github.com/Team488/SeriouslyCommonLib/pull/473

# Future work

I didn't touch the field oriented swerve drive logic

# How this was tested
- [ ] unit tests added
- [ ] tested on robot
