### PR TITLE
Log info for drive to nearest good scoring position command

### DIFF
--- a/src/main/java/competition/subsystems/drive/commands/DriveToNearestGoodScoringPositionCommand.java
+++ b/src/main/java/competition/subsystems/drive/commands/DriveToNearestGoodScoringPositionCommand.java
@@ -49,7 +49,7 @@ public class DriveToNearestGoodScoringPositionCommand extends SwerveSimpleTrajec
         }
 
         ArrayList<XbotSwervePoint> swervePoints = new ArrayList<>();
-        swervePoints.add(new XbotSwervePoint(nearestScoringLocation., 10));
+        swervePoints.add(new XbotSwervePoint(scoringLocationPose, 10));
         this.logic.setKeyPoints(swervePoints);
         this.logic.setEnableConstantVelocity(true);
         this.logic.setConstantVelocity(drive.getMaxTargetSpeedMetersPerSecond());


### PR DESCRIPTION
# Why are we doing this?
so we can try to debug any issues with this command going to weird spots

# Whats changing?
added log.info to record what location this command wants to go to

# How this was tested
- sim
