### PR TITLE
Change getClosestNote() to return an Optional

### DIFF
--- a/src/main/java/competition/commandgroups/DriveToGivenNoteWithVisionCommand.java
+++ b/src/main/java/competition/commandgroups/DriveToGivenNoteWithVisionCommand.java
@@ -113,8 +113,8 @@ public class DriveToGivenNoteWithVisionCommand extends DriveToGivenNoteCommand {
     private Pose2d getNearestVisionNote() {
         var notePose = oracle.getNoteMap().getClosestAvailableNote(
                 pose.getCurrentPose2d(), false);
-        if (notePose != null) {
-            return notePose.toPose2d();
+        if (notePose.isPresent()) {
+            return notePose.get().toPose2d();
         }
         return null;
     }

--- a/src/main/java/competition/subsystems/drive/commands/PointAtNoteCommand.java
+++ b/src/main/java/competition/subsystems/drive/commands/PointAtNoteCommand.java
@@ -6,6 +6,7 @@ import competition.subsystems.oracle.DynamicOracle;
 import competition.subsystems.pose.PoseSubsystem;
 import edu.wpi.first.math.VecBuilder;
 import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Transform2d;
 import edu.wpi.first.math.geometry.Translation2d;
@@ -118,9 +119,10 @@ public class PointAtNoteCommand extends BaseCommand {
 
     private Pose2d getClosestAvailableNote() {
         var virtualPoint = getProjectedPoint();
-        var notePosition = this.oracle.getNoteMap().getClosestAvailableNote(virtualPoint, false);
+        var maybeNotePosition = this.oracle.getNoteMap().getClosestAvailableNote(virtualPoint, false);
 
-        if (notePosition != null) {
+        if (maybeNotePosition.isPresent()) {
+            Pose3d notePosition = maybeNotePosition.get();
             if (this.savedNotePosition == null) {
                 this.savedNotePosition = notePosition.toPose2d();
             };

--- a/src/main/java/competition/subsystems/drive/commands/PointAtNoteWithBearingCommand.java
+++ b/src/main/java/competition/subsystems/drive/commands/PointAtNoteWithBearingCommand.java
@@ -162,12 +162,8 @@ public class PointAtNoteWithBearingCommand extends SwerveDriveWithJoysticksComma
 
     private Optional<Pose2d> getClosestAvailableNote() {
         var virtualPoint = getProjectedPoint();
-        var notePosition = this.oracle.getNoteMap().getClosestAvailableNote(virtualPoint, false);
-        if(notePosition != null) {
-            return Optional.of(notePosition.toPose2d());
-        } else {
-            return Optional.empty();
-        }
+        var maybeNotePosition = this.oracle.getNoteMap().getClosestAvailableNote(virtualPoint, false);
+        return maybeNotePosition.map((note) -> note.toPose2d());
     }
 
     private Pose2d getProjectedPoint() {

--- a/src/main/java/competition/subsystems/oracle/DynamicOracle.java
+++ b/src/main/java/competition/subsystems/oracle/DynamicOracle.java
@@ -416,20 +416,20 @@ public class DynamicOracle extends BaseSubsystem {
 
     private Pose2d getVisionSuggestedNotePoseWithinDistance(double searchDistance) {
         var potentialNote = noteMap.getClosestAvailableNote(pose.getCurrentPose2d(), false);
-        if (potentialNote == null) {
+        if (potentialNote.isEmpty()) {
             // No note
             return null;
         }
 
         double distanceToNote = pose.getCurrentPose2d().getTranslation().getDistance(
-                potentialNote.toPose2d().getTranslation());
+                potentialNote.get().toPose2d().getTranslation());
 
         if (distanceToNote > searchDistance) {
             // Too far
             return null;
         }
 
-        return potentialNote.toPose2d();
+        return potentialNote.get().toPose2d();
     }
 
     private void applyVisionNotePoseToStateMachine(Pose2d visionNotePose) {

--- a/src/main/java/competition/subsystems/oracle/NoteMap.java
+++ b/src/main/java/competition/subsystems/oracle/NoteMap.java
@@ -11,6 +11,7 @@ import xbot.common.controls.sensors.XTimer;
 import javax.inject.Singleton;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Singleton
 public class NoteMap extends ReservableLocationMap<Note> {
@@ -101,7 +102,7 @@ public class NoteMap extends ReservableLocationMap<Note> {
         }
     }
 
-    public Pose3d getClosestAvailableNote(Pose2d referencePoint, boolean includeStaticNotes) {
+    public Optional<Pose3d> getClosestAvailableNote(Pose2d referencePoint, boolean includeStaticNotes) {
         double closestDistance = Double.MAX_VALUE;
         Note closestNote = null;
         ArrayList<Note> allNotes;
@@ -121,13 +122,13 @@ public class NoteMap extends ReservableLocationMap<Note> {
             }
         }
         if (closestNote != null) {
-            return new Pose3d(new Translation3d(
+            return Optional.of(new Pose3d(new Translation3d(
                     closestNote.getLocation().getX(),
                     closestNote.getLocation().getY(),
                     0.025),
-                    new Rotation3d(0,0,0));
+                    new Rotation3d(0,0,0)));
         }
-        return null;
+        return Optional.empty();
     }
 
     public List<Note> getAllAvailableNotes() {

--- a/src/test/java/competition/subsystems/oracle/NoteMapTest.java
+++ b/src/test/java/competition/subsystems/oracle/NoteMapTest.java
@@ -57,10 +57,10 @@ public class NoteMapTest extends BaseCompetitionTest {
     @Test
     public void testGetClosestAvailableNote() {
         var notePose = noteMap.getClosestAvailableNote(PoseSubsystem.BlueSpikeMiddle, true);
-        assertEquals(PoseSubsystem.BlueSpikeMiddle, notePose.toPose2d());
+        assertEquals(PoseSubsystem.BlueSpikeMiddle, notePose.get().toPose2d());
 
         noteMap.addVisionNote(new Pose2d());
         notePose = noteMap.getClosestAvailableNote(PoseSubsystem.BlueSpikeMiddle, true);
-        assertEquals(PoseSubsystem.BlueSpikeMiddle, notePose.toPose2d());
+        assertEquals(PoseSubsystem.BlueSpikeMiddle, notePose.get().toPose2d());
     }
 }


### PR DESCRIPTION
# Why are we doing this?

We crashed the robot when we missed checking for null somewhere, this way the compiler will enforce it.

Asana task URL:

# Whats changing?

# Questions/notes for reviewers

# How this was tested
- [ ] unit tests added
- [ ] tested on robot
